### PR TITLE
Fixed

### DIFF
--- a/src/controllers/FetchController.php
+++ b/src/controllers/FetchController.php
@@ -319,7 +319,7 @@ class FetchController extends Controller {
 					$response['message'] = 'A template path was not defined in your AJAX "data" parameters.';
 
 					try {
-						$query = Craft::$app->getRequest()->getBodyParams();
+						$query = (object)Craft::$app->getRequest()->getBodyParams();
 					} catch(\Exception $e) {
 						$response['error'] = true;
 						$response['message'] = $e->getMessage();


### PR DESCRIPTION
- When using the Data Fetcher with Ajax, the query needs to be converted to an object so as to keep syntax between 'fetch' and 'ajax' the same no matter what the Browser support.